### PR TITLE
Patch to list only dahsboards user owns

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -103,6 +103,15 @@ class DashboardFilter(SupersetFilter):
 
     def apply(self, query, func):  # noqa
         if security_manager.all_datasource_access():
+            Dash = models.Dashboard  # noqa
+            User = security_manager.user_model
+            owner_ids_qry = (
+                db.session
+                .query(Dash.id)
+                .join(Dash.owners)
+                .filter(User.id == User.get_user_id())
+            )
+            query = query.filter(Dash.id.in_(owner_ids_qry))
             return query
         Slice = models.Slice  # noqa
         Dash = models.Dashboard  # noqa


### PR DESCRIPTION
**What does this PR do?**
Patch `views/core.py` file to list only dashboards the user own.

**How should this be manually tested?**
-Run `Superset`
-Create a new user of Gepp type (or use an existing one)
-Also from admin add ownership of one (or a few dashboards)
-Login as the Gepp user of the second step
-Go to `Dahsboards` on upper menu
-You should see listed only dashboards that were explicitly assigned to such user